### PR TITLE
Only sort records in view if view exists

### DIFF
--- a/notion/collection.py
+++ b/notion/collection.py
@@ -214,7 +214,8 @@ class Collection(Record):
                 for view in self.parent.views:
                     if view is None or isinstance(view, CalendarView):
                         continue
-                    view.set("page_sort", view.get("page_sort", []) + [row_id])
+                    if view:
+                        view.set("page_sort", view.get("page_sort", []) + [row_id])
 
         return row
 


### PR DESCRIPTION
via https://github.com/jamalex/notion-py/pull/205 . Looks like an obvious bugfix.